### PR TITLE
Add .gitignore file to prevent temp files from being commited to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# ignore Java class files except for the HelloWorld.class sample
+*.class
+!HelloWorld.class
+
+# IDE files
+# intelliJ
+.idea
+*.iml
+
+# VScode
+.vscode
+
+# Mac OS Files
+.DS_Store


### PR DESCRIPTION
Linked issue: Resolves https://github.com/underscoreanuj/code-memo/issues/1

What was done in this PR?
A `.gitignore` file was added to prevent temporary or output files being commited to the repository by mistake.

List of files ignored with this change:
- all java class files except the `HelloWorld.class` sample file
- IDE generated project files for intellij & VS Code
- Mac OS `.DS_Store` files