### PR TITLE
Additions to .gitignore for cpp, javascript and golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,27 @@
-# ignore Java class files except for the HelloWorld.class sample
+# Java files
+# https://github.com/github/gitignore/blob/master/Java.gitignore
 *.class
 !HelloWorld.class
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
 
 # IDE files
 # intelliJ


### PR DESCRIPTION
Linked issue: Resolves #1

What was done in this PR?
Added gitignore syntax for [cpp](https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore), [javascript](https://github.com/github/gitignore/blob/master/Node.gitignore) and [golang](https://github.com/github/gitignore/blob/master/Go.gitignore) based on [github gitignore templates](https://github.com/github/gitignore)
Also added additional [Java exclusions](https://github.com/github/gitignore/blob/master/Java.gitignore)